### PR TITLE
fix: Cloudflare Pages デプロイ時の UTF-8 エラーを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,4 +39,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy docs/.vitepress/dist --project-name=isms-guide
+          command: pages deploy docs/.vitepress/dist --project-name=isms-guide --commit-message="Deploy ${{ github.sha }}"


### PR DESCRIPTION
## 概要

日本語のコミットメッセージが Cloudflare Pages API で UTF-8 エラーを引き起こす問題を修正。

## 原因

```
Invalid commit message, it must be a valid UTF-8 string. [code: 8000111]
```

Cloudflare Pages の wrangler が日本語コミットメッセージを正しく処理できない。

## 修正内容

`--commit-message` オプションを追加し、コミット SHA を使用した英語メッセージを指定。

## 関連

- 失敗した run: https://github.com/btajp/isms-guide/actions/runs/21333937217