### PR TITLE
chore: MIT/CC0 デュアルライセンス化とフッター更新

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,11 @@
-MIT License
+This project is dual-licensed under MIT License and CC0 1.0 Universal.
+You may choose either license.
 
-Copyright (c) 2026 btajp
+================================================================================
+MIT License
+================================================================================
+
+Copyright (c) 2026 BTAJP
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,3 +24,17 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+================================================================================
+CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
+================================================================================
+
+The person who associated a work with this deed has dedicated the work to the
+public domain by waiving all of his or her rights to the work worldwide under
+copyright law, including all related and neighboring rights, to the extent
+allowed by law.
+
+You can copy, modify, distribute and perform the work, even for commercial
+purposes, all without asking permission.
+
+For more information, see: https://creativecommons.org/publicdomain/zero/1.0/

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -153,8 +153,8 @@ export default withMermaid(
 
       // Footer
       footer: {
-        message: 'MIT License | <a href="/about/copyright">著作権・出典について</a>',
-        copyright: 'Copyright 2024 btajp'
+        message: '<a href="https://github.com/btajp/isms-guide/blob/main/LICENSE">MIT / CC0 Dual License</a> | <a href="/about/copyright">著作権・出典について</a>',
+        copyright: 'Copyright 2026 <a href="https://btajp.org">BTAJP</a>'
       },
 
       // Edit link


### PR DESCRIPTION
## 概要

- MIT / CC0 デュアルライセンスに変更
- フッターの著作権表示を更新

## 変更内容

### LICENSE
- MIT 単独 → MIT / CC0 デュアルライセンス
- btajp → BTAJP

### config.mts (フッター)
- `MIT License` → `MIT / CC0 Dual License`
- `Copyright 2024 btajp` → `Copyright 2026 BTAJP` (BTAJPはhttps://btajp.orgにリンク)