### PR TITLE
chore: ISSUEテンプレートを追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: "ディスカッション"
+    url: https://github.com/btajp/isms-guide/discussions
+    about: "質問や議論は Discussions をご利用ください"

--- a/.github/ISSUE_TEMPLATE/content.yml
+++ b/.github/ISSUE_TEMPLATE/content.yml
@@ -1,0 +1,59 @@
+name: "コンテンツに関する報告・提案"
+description: "ドキュメント内容、テンプレート、解説の改善提案や誤りの報告"
+labels: ["content"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        コンテンツに関するご報告・ご提案ありがとうございます。
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: 種類
+      description: この Issue の種類を選択してください
+      options:
+        - 誤字・脱字の報告
+        - 内容の誤りの報告
+        - 解説の改善提案
+        - テンプレートの改善提案
+        - 新規コンテンツの提案
+        - その他
+    validations:
+      required: true
+
+  - type: input
+    id: page
+    attributes:
+      label: 対象ページ
+      description: 該当するページの URL またはファイルパス
+      placeholder: "例: https://isms-guide.com/requirements/6-1-2 または docs/requirements/6-1-2.md"
+    validations:
+      required: true
+
+  - type: textarea
+    id: current
+    attributes:
+      label: 現状
+      description: 現在の記載内容や問題点を記載してください
+      placeholder: "現在「〇〇」と記載されていますが..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: 提案内容
+      description: どのように修正・改善すべきかを記載してください
+      placeholder: "「△△」に修正すべきです。理由は..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reference
+    attributes:
+      label: 参考情報
+      description: 根拠となる情報源やリンクがあれば記載してください（任意）
+      placeholder: "ISO/IEC 27001:2022 の箇条 X.X.X によると..."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/technical.yml
+++ b/.github/ISSUE_TEMPLATE/technical.yml
@@ -1,0 +1,79 @@
+name: "技術的な問題・改善"
+description: "サイト構築、ビルド、表示、機能に関するバグ報告や改善提案"
+labels: ["technical"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        技術的な問題のご報告ありがとうございます。
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: 種類
+      description: この Issue の種類を選択してください
+      options:
+        - バグ報告
+        - 機能改善の提案
+        - 新機能の提案
+        - パフォーマンス問題
+        - アクセシビリティ問題
+        - その他
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: 該当領域
+      description: 問題が発生している領域を選択してください
+      options:
+        - VitePress / サイト表示
+        - ビルド / デプロイ
+        - 検索機能
+        - ナビゲーション / サイドバー
+        - レスポンシブ / モバイル表示
+        - Mermaid 図表
+        - CI / GitHub Actions
+        - その他
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 問題の説明
+      description: 発生している問題や提案内容を具体的に記載してください
+      placeholder: "〇〇のページで△△が表示されない..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 再現手順
+      description: バグの場合、再現手順を記載してください（任意）
+      placeholder: |
+        1. 〇〇ページにアクセス
+        2. △△をクリック
+        3. エラーが発生
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待される動作
+      description: 本来どのように動作すべきかを記載してください（任意）
+      placeholder: "正常に△△が表示されるべき"
+    validations:
+      required: false
+
+  - type: input
+    id: environment
+    attributes:
+      label: 環境
+      description: ブラウザ、OS などの環境情報（任意）
+      placeholder: "例: Chrome 120 / macOS Sonoma"
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

GitHub ISSUE テンプレートを2種類追加しました。

### コンテンツに関する報告・提案 (`content.yml`)
- 誤字・脱字、内容の誤り、解説の改善提案など
- ラベル: `content`

### 技術的な問題・改善 (`technical.yml`)
- VitePress、ビルド、表示、機能に関するバグ報告や改善提案
- ラベル: `technical`

### 設定 (`config.yml`)
- ブランクISSUEも許可
- Discussions へのリンクを追加

## Test plan
- [ ] New Issue 作成時にテンプレート選択画面が表示されることを確認
- [ ] 各テンプレートのフォームが正しく表示されることを確認