### PR TITLE
feat: 全ページでフッターを常に表示する

### DIFF
--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import DefaultTheme from 'vitepress/theme'
+import { useData } from 'vitepress'
+
+const { Layout } = DefaultTheme
+const { theme } = useData()
+</script>
+
+<template>
+  <Layout>
+    <template #layout-bottom>
+      <footer class="custom-footer">
+        <div class="footer-content">
+          <p class="footer-message" v-html="theme.footer?.message"></p>
+          <p class="footer-copyright" v-html="theme.footer?.copyright"></p>
+        </div>
+      </footer>
+    </template>
+  </Layout>
+</template>
+
+<style scoped>
+.custom-footer {
+  border-top: 1px solid var(--vp-c-divider);
+  padding: 24px;
+  background-color: var(--vp-c-bg);
+}
+
+.footer-content {
+  max-width: 1152px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.footer-message {
+  font-size: 14px;
+  color: var(--vp-c-text-2);
+  margin-bottom: 8px;
+}
+
+.footer-message :deep(a) {
+  color: var(--vp-c-brand-1);
+  text-decoration: none;
+}
+
+.footer-message :deep(a:hover) {
+  text-decoration: underline;
+}
+
+.footer-copyright {
+  font-size: 14px;
+  color: var(--vp-c-text-3);
+}
+
+.footer-copyright :deep(a) {
+  color: var(--vp-c-text-2);
+  text-decoration: none;
+}
+
+.footer-copyright :deep(a:hover) {
+  text-decoration: underline;
+}
+</style>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -28,3 +28,8 @@
   --vp-home-hero-name-color: transparent;
   --vp-home-hero-name-background: linear-gradient(135deg, #10b981 0%, #047857 100%);
 }
+
+/* Hide default VitePress footer to use custom footer on all pages */
+.VPFooter {
+  display: none !important;
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,4 +1,8 @@
 import DefaultTheme from 'vitepress/theme'
+import Layout from './Layout.vue'
 import './custom.css'
 
-export default DefaultTheme
+export default {
+  extends: DefaultTheme,
+  Layout
+}


### PR DESCRIPTION
## 概要
全てのページでフッター（ライセンス情報・著作権表示）を常に表示するようにしました。

## 変更内容
- カスタム `Layout.vue` コンポーネントを作成
- VitePressの `layout-bottom` スロットを使用してフッターを全ページに配置
- デフォルトの `VPFooter` をCSSで非表示にして重複を防止

## 技術的な詳細
- `home` レイアウトと `doc` レイアウトの両方でフッターが表示されるようになりました
- フッターの内容は `config.mts` の `footer` 設定を参照

Closes #48