### PR TITLE
fix: フッターを横全幅で独立表示する

### DIFF
--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -21,15 +21,28 @@ const { theme } = useData()
 
 <style scoped>
 .custom-footer {
+  /* Full width positioning - break out of parent container */
+  position: relative;
+  width: 100vw;
+  left: 50%;
+  right: 50%;
+  margin-left: -50vw;
+  margin-right: -50vw;
+
+  /* Styling */
   border-top: 1px solid var(--vp-c-divider);
   padding: 24px;
   background-color: var(--vp-c-bg);
+
+  /* Ensure footer is above any overlapping elements */
+  z-index: 10;
 }
 
 .footer-content {
   max-width: 1152px;
   margin: 0 auto;
   text-align: center;
+  padding: 0 24px;
 }
 
 .footer-message {


### PR DESCRIPTION
## 概要
フッターをサイドバーから独立させ、横全幅で表示するようにしました。

## 変更内容
- CSSの `width: 100vw` と `margin-left: -50vw` テクニックで親コンテナからブレイクアウト
- `z-index: 10` でサイドバーとの重なりを解消
- 全ページで一貫したフッター表示を実現

## 修正前の問題
- 右サイドバー（目次）とフッターが重なっていた
- 左サイドバーとフッターが分離して表示されていた

## 修正後
- フッターはページ下部に横全幅で独立表示
- Homeページと同様の一貫した表示

Closes #56