### PR TITLE
fix: フッターのレイアウトを改善

### DIFF
--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -21,28 +21,16 @@ const { theme } = useData()
 
 <style scoped>
 .custom-footer {
-  /* Full width positioning - break out of parent container */
-  position: relative;
-  width: 100vw;
-  left: 50%;
-  right: 50%;
-  margin-left: -50vw;
-  margin-right: -50vw;
-
-  /* Styling */
-  border-top: 1px solid var(--vp-c-divider);
   padding: 24px;
   background-color: var(--vp-c-bg);
-
-  /* Ensure footer is above any overlapping elements */
-  z-index: 10;
 }
 
 .footer-content {
-  max-width: 1152px;
+  max-width: 688px;
   margin: 0 auto;
+  border-top: 1px solid var(--vp-c-divider);
+  padding-top: 24px;
   text-align: center;
-  padding: 0 24px;
 }
 
 .footer-message {


### PR DESCRIPTION
## 概要
フッターのレイアウトを改善し、右サイドバーとの重なり問題を解決しました。

## 変更内容
- フッターをコンテンツ幅（688px）に制限
- `border-top` を `footer-content` に移動してサイドバーとの重なりを解消
- VitePressのオーバーライドを最小限に抑えてメンテナンス性を維持

## 技術的な判断
- 横全幅フッターはVitePressの構造上、大幅なCSSオーバーライドが必要でメンテナンス性が低下
- コンテンツ幅に収めることでVitePressの標準レイアウトと調和

Closes #56