### PR TITLE
fix: Mermaidダイアグラムのシンタックスエラーを修正

### DIFF
--- a/docs/glossary/index.md
+++ b/docs/glossary/index.md
@@ -1,3 +1,8 @@
+---
+prev: false
+next: false
+---
+
 # 用語集
 
 ISMS（情報セキュリティマネジメントシステム）に関する重要な用語を解説します。
@@ -104,9 +109,9 @@ Plan-Do-Check-Act サイクル。継続的改善のための管理手法。
 
 ```mermaid
 graph TD
-    P[Plan 計画] --> D[Do 実行]
-    D --> C[Check 評価]
-    C --> A[Act 改善]
+    P["Plan (計画)"] --> D["Do (実行)"]
+    D --> C["Check (評価)"]
+    C --> A["Act (改善)"]
     A --> P
 ```
 


### PR DESCRIPTION
## Summary
- 用語集ページのPDCAダイアグラムでMermaidがシンタックスエラーを出していた問題を修正
- ノードラベル内の日本語文字をダブルクォートで囲むことでパースエラーを解消
- 「Syntax error in text」エラーメッセージの一部「ext」が画面左下に表示されていた

## Changes
- `docs/glossary/index.md`: Mermaidノードラベルの構文を修正
- 用語集ページのfrontmatterに`prev: false`, `next: false`を追加

## Test plan
- [ ] 用語集ページでPDCAダイアグラムが正しく表示される
- [ ] 画面左下に「ext」テキストが表示されない