### PR TITLE
feat: OGP自動生成を追加

### DIFF
--- a/.kiro/specs/ogp-generation/design.md
+++ b/.kiro/specs/ogp-generation/design.md
@@ -1,0 +1,133 @@
+# Design: OGP自動生成
+
+## Architecture Overview
+
+VitePressの`transformHead`フックを使用して、各ページのビルド時にOGPメタタグを動的に生成する。
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    VitePress Build                          │
+│                                                             │
+│  ┌─────────────┐    ┌──────────────┐    ┌───────────────┐  │
+│  │   Markdown  │───▶│ transformHead│───▶│  HTML Output  │  │
+│  │   + Front-  │    │    Hook      │    │  with OGP     │  │
+│  │   matter    │    │              │    │  Meta Tags    │  │
+│  └─────────────┘    └──────────────┘    └───────────────┘  │
+│                            │                                │
+│                            ▼                                │
+│                   ┌──────────────┐                          │
+│                   │ PageData:    │                          │
+│                   │ - title      │                          │
+│                   │ - description│                          │
+│                   │ - relativePath│                         │
+│                   └──────────────┘                          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Components
+
+### 1. transformHead Hook (config.mts)
+
+```typescript
+// docs/.vitepress/config.mts
+export default defineConfig({
+  // 既存の設定...
+
+  transformHead({ pageData }) {
+    const head: HeadConfig[] = []
+    const siteUrl = 'https://isms-guide.com'
+
+    // og:title
+    const title = pageData.frontmatter.title || pageData.title || 'ISMS Guide'
+    head.push(['meta', { property: 'og:title', content: title }])
+
+    // og:description
+    const description = pageData.frontmatter.description ||
+      'ISO/IEC 27001:2022 対応 ISMS 構築ガイド'
+    head.push(['meta', { property: 'og:description', content: description }])
+
+    // og:url
+    const url = `${siteUrl}/${pageData.relativePath.replace(/\.md$/, '.html').replace(/index\.html$/, '')}`
+    head.push(['meta', { property: 'og:url', content: url }])
+
+    // twitter:card
+    head.push(['meta', { name: 'twitter:card', content: 'summary' }])
+    head.push(['meta', { name: 'twitter:title', content: title }])
+    head.push(['meta', { name: 'twitter:description', content: description }])
+
+    return head
+  }
+})
+```
+
+## Design Decisions
+
+### D1: メタタグの属性
+
+**決定**: OGPメタタグには`property`属性を使用、Twitterカードには`name`属性を使用
+
+**根拠**:
+- OGP仕様では`property`属性が正式
+- Twitter Cards仕様では`name`属性が標準
+- 現在の設定では`name`属性を使用しているが、`property`に修正
+
+### D2: 既存head設定との共存
+
+**決定**: 静的なhead設定（og:type, og:locale, og:site_name）はそのまま維持し、動的なタグのみtransformHeadで生成
+
+**根拠**:
+- og:type, og:locale, og:site_nameは全ページ共通
+- og:title, og:description, og:urlはページ固有
+- 重複を避けるため役割を分離
+
+### D3: URL生成ロジック
+
+**決定**: siteUrlを定数として定義し、relativePathから完全なURLを生成
+
+**変換ルール**:
+- `index.md` → `https://isms-guide.com/`
+- `requirements/index.md` → `https://isms-guide.com/requirements/`
+- `controls/a-5-5.md` → `https://isms-guide.com/controls/a-5-5.html`
+
+### D4: デフォルト値
+
+**決定**: frontmatterにtitle/descriptionがない場合はサイトデフォルトを使用
+
+| フィールド | フォールバック順序 |
+|-----------|-------------------|
+| title | frontmatter.title → pageData.title → 'ISMS Guide' |
+| description | frontmatter.description → サイトdescription |
+
+## File Changes
+
+### Modified Files
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `docs/.vitepress/config.mts` | transformHeadフック追加、head設定の属性修正 |
+
+## Testing Strategy
+
+### 手動テスト
+
+1. `npm run build`でビルド実行
+2. 生成されたHTMLファイルを確認
+3. 以下のメタタグが正しく生成されていることを確認:
+   - `<meta property="og:title" content="...">`
+   - `<meta property="og:description" content="...">`
+   - `<meta property="og:url" content="...">`
+   - `<meta name="twitter:card" content="summary">`
+   - `<meta name="twitter:title" content="...">`
+   - `<meta name="twitter:description" content="...">`
+
+### 検証ページ
+
+- トップページ (`/`)
+- 要求事項ページ (`/requirements/`)
+- 管理策詳細ページ (`/controls/a-5-5`)
+- テンプレートページ (`/templates/`)
+
+### SNSデバッガーでの確認
+
+- [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/)
+- [Twitter Card Validator](https://cards-dev.twitter.com/validator)

--- a/.kiro/specs/ogp-generation/requirements.md
+++ b/.kiro/specs/ogp-generation/requirements.md
@@ -1,0 +1,52 @@
+# Requirements: OGP自動生成
+
+## Overview
+
+各ページのOGP（Open Graph Protocol）メタタグを自動生成し、SNSでのシェア時に適切なプレビューが表示されるようにする。
+
+## User Stories
+
+### US-1: ページ共有時のプレビュー表示
+
+**As** サイト閲覧者
+**I want** SNSでページをシェアした際に適切なタイトルと説明が表示される
+**So that** シェア先でページの内容が伝わりやすくなる
+
+#### Acceptance Criteria
+
+1. **AC-1.1**: WHEN ページがビルドされる THE SYSTEM SHALL そのページの `og:title` メタタグを自動生成する
+2. **AC-1.2**: WHEN ページがビルドされる THE SYSTEM SHALL そのページの `og:description` メタタグを自動生成する
+3. **AC-1.3**: WHEN ページがビルドされる THE SYSTEM SHALL そのページの `og:url` メタタグを自動生成する
+4. **AC-1.4**: WHEN frontmatterに `title` が設定されている THE SYSTEM SHALL その値を `og:title` に使用する
+5. **AC-1.5**: WHEN frontmatterに `description` が設定されている THE SYSTEM SHALL その値を `og:description` に使用する
+6. **AC-1.6**: WHEN frontmatterに `title` が設定されていない THE SYSTEM SHALL サイトのデフォルトタイトルを使用する
+
+### US-2: Twitter/X カード対応
+
+**As** サイト運営者
+**I want** Twitter/X でシェアした際にサマリーカードが表示される
+**So that** より多くのユーザーにリーチできる
+
+#### Acceptance Criteria
+
+1. **AC-2.1**: WHEN ページがビルドされる THE SYSTEM SHALL `twitter:card` メタタグを生成する
+2. **AC-2.2**: WHEN ページがビルドされる THE SYSTEM SHALL `twitter:title` メタタグを生成する
+3. **AC-2.3**: WHEN ページがビルドされる THE SYSTEM SHALL `twitter:description` メタタグを生成する
+
+## Non-Functional Requirements
+
+- **Performance**: ビルド時間への影響は最小限に抑える
+- **Compatibility**: VitePress 1.x との互換性を維持する
+- **Maintainability**: 設定は `config.mts` 内で完結させる
+
+## Out of Scope
+
+- OGP画像の自動生成（Phase 2 として別途検討）
+- カスタムOGP画像のアップロード機能
+- SNS固有の追加メタタグ（Facebook App ID等）
+
+## Technical Notes
+
+- VitePress の `transformHead` フックを使用
+- 既存の `head` 設定との競合を避ける
+- `property` 属性を使用（`name` ではなく）

--- a/.kiro/specs/ogp-generation/tasks.md
+++ b/.kiro/specs/ogp-generation/tasks.md
@@ -1,0 +1,131 @@
+# Tasks: OGP自動生成
+
+## Task 1: 既存head設定の属性修正
+
+### Description
+現在のOGPメタタグは`name`属性を使用しているが、OGP仕様に準拠して`property`属性に修正する。
+
+### Files to Modify
+- `docs/.vitepress/config.mts`
+
+### Changes
+```typescript
+// Before
+['meta', { name: 'og:type', content: 'website' }],
+['meta', { name: 'og:locale', content: 'ja_JP' }],
+['meta', { name: 'og:site_name', content: 'ISMS Guide' }],
+
+// After
+['meta', { property: 'og:type', content: 'website' }],
+['meta', { property: 'og:locale', content: 'ja_JP' }],
+['meta', { property: 'og:site_name', content: 'ISMS Guide' }],
+```
+
+### Acceptance Criteria
+- [x] AC-1.1: og:type, og:locale, og:site_nameがproperty属性で出力される
+
+---
+
+## Task 2: transformHeadフックの実装
+
+### Description
+VitePressのtransformHeadフックを使用して、各ページのOGPメタタグを動的に生成する。
+
+### Files to Modify
+- `docs/.vitepress/config.mts`
+
+### Implementation
+```typescript
+import { defineConfig, HeadConfig } from 'vitepress'
+
+export default defineConfig({
+  // ... 既存設定
+
+  transformHead({ pageData }) {
+    const head: HeadConfig[] = []
+    const siteUrl = 'https://isms-guide.com'
+
+    // og:title
+    const title = pageData.frontmatter.title || pageData.title || 'ISMS Guide'
+    head.push(['meta', { property: 'og:title', content: title }])
+
+    // og:description
+    const description = pageData.frontmatter.description ||
+      'ISO/IEC 27001:2022 対応 ISMS 構築ガイド'
+    head.push(['meta', { property: 'og:description', content: description }])
+
+    // og:url
+    const relativePath = pageData.relativePath
+      .replace(/\.md$/, '.html')
+      .replace(/index\.html$/, '')
+    const url = `${siteUrl}/${relativePath}`
+    head.push(['meta', { property: 'og:url', content: url }])
+
+    // Twitter Cards
+    head.push(['meta', { name: 'twitter:card', content: 'summary' }])
+    head.push(['meta', { name: 'twitter:title', content: title }])
+    head.push(['meta', { name: 'twitter:description', content: description }])
+
+    return head
+  }
+})
+```
+
+### Acceptance Criteria
+- [ ] AC-1.1: og:titleがページごとに自動生成される
+- [ ] AC-1.2: og:descriptionがページごとに自動生成される
+- [ ] AC-1.3: og:urlがページごとに自動生成される
+- [ ] AC-1.4: frontmatterのtitleがog:titleに使用される
+- [ ] AC-1.5: frontmatterのdescriptionがog:descriptionに使用される
+- [ ] AC-1.6: titleがない場合はサイトデフォルトが使用される
+- [ ] AC-2.1: twitter:cardが生成される
+- [ ] AC-2.2: twitter:titleが生成される
+- [ ] AC-2.3: twitter:descriptionが生成される
+
+---
+
+## Task 3: ビルド検証
+
+### Description
+ビルドを実行し、生成されたHTMLファイルでOGPメタタグが正しく出力されていることを確認する。
+
+### Verification Steps
+
+1. ビルド実行
+```bash
+npm run build
+```
+
+2. 生成ファイルの確認
+```bash
+# トップページ
+grep -A1 'og:title\|og:description\|og:url\|twitter:' docs/.vitepress/dist/index.html
+
+# 要求事項ページ
+grep -A1 'og:title\|og:description\|og:url\|twitter:' docs/.vitepress/dist/requirements/index.html
+
+# 管理策詳細ページ
+grep -A1 'og:title\|og:description\|og:url\|twitter:' docs/.vitepress/dist/controls/a-5-5.html
+```
+
+### Expected Output
+各ページで以下のメタタグが出力されること:
+- `<meta property="og:title" content="ページタイトル">`
+- `<meta property="og:description" content="ページ説明">`
+- `<meta property="og:url" content="https://isms-guide.com/path/">`
+- `<meta name="twitter:card" content="summary">`
+- `<meta name="twitter:title" content="ページタイトル">`
+- `<meta name="twitter:description" content="ページ説明">`
+
+### Acceptance Criteria
+- [ ] 全てのACが満たされていることを確認
+
+---
+
+## Implementation Order
+
+1. **Task 1**: 既存head設定の属性修正（5分）
+2. **Task 2**: transformHeadフックの実装（15分）
+3. **Task 3**: ビルド検証（10分）
+
+**合計見積もり時間**: 30分

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitepress'
+import { defineConfig, HeadConfig } from 'vitepress'
 import { withMermaid } from 'vitepress-plugin-mermaid'
 
 // https://vitepress.dev/reference/site-config
@@ -23,9 +23,9 @@ export default withMermaid(
     // Head meta tags
     head: [
       ['meta', { name: 'theme-color', content: '#3eaf7c' }],
-      ['meta', { name: 'og:type', content: 'website' }],
-      ['meta', { name: 'og:locale', content: 'ja_JP' }],
-      ['meta', { name: 'og:site_name', content: 'ISMS Guide' }],
+      ['meta', { property: 'og:type', content: 'website' }],
+      ['meta', { property: 'og:locale', content: 'ja_JP' }],
+      ['meta', { property: 'og:site_name', content: 'ISMS Guide' }],
       // Favicon
       ['link', { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' }],
       ['link', { rel: 'icon', type: 'image/png', sizes: '96x96', href: '/favicon-96x96.png' }],
@@ -238,6 +238,35 @@ export default withMermaid(
     },
 
     // Last updated
-    lastUpdated: true
+    lastUpdated: true,
+
+    // Dynamic OGP meta tags per page
+    transformHead({ pageData }) {
+      const head: HeadConfig[] = []
+      const siteUrl = 'https://isms-guide.com'
+
+      // og:title
+      const title = pageData.frontmatter.title || pageData.title || 'ISMS Guide'
+      head.push(['meta', { property: 'og:title', content: title }])
+
+      // og:description
+      const description =
+        pageData.frontmatter.description || 'ISO/IEC 27001:2022 対応 ISMS 構築ガイド'
+      head.push(['meta', { property: 'og:description', content: description }])
+
+      // og:url
+      const relativePath = pageData.relativePath
+        .replace(/\.md$/, '.html')
+        .replace(/index\.html$/, '')
+      const url = `${siteUrl}/${relativePath}`
+      head.push(['meta', { property: 'og:url', content: url }])
+
+      // Twitter Cards
+      head.push(['meta', { name: 'twitter:card', content: 'summary' }])
+      head.push(['meta', { name: 'twitter:title', content: title }])
+      head.push(['meta', { name: 'twitter:description', content: description }])
+
+      return head
+    }
   })
 )


### PR DESCRIPTION
## Summary

- VitePressの`transformHead`フックを使用してページごとにOGPメタタグを動的生成
- 既存のOGPメタタグの属性を`name`から`property`に修正（OGP仕様準拠）
- `og:title`, `og:description`, `og:url`をページごとに自動設定
- Twitter Cards (`twitter:card`, `twitter:title`, `twitter:description`) に対応

## Test plan

- [x] ビルド成功
- [x] トップページで`og:title`が「ISMS Guide」
- [x] 要求事項ページで`og:title`が「要求事項（箇条4-10）」
- [x] 管理策詳細ページで`og:title`が「A.5.5 関係当局との連絡」
- [x] 全ページで`twitter:card`が「summary」
- [x] 静的OGPタグ（og:type, og:locale, og:site_name）が`property`属性で出力

closes #70