### PR TITLE
chore: OGPテンプレートを刷新し、正方形クロップ対応

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -297,9 +297,13 @@ export default withMermaid(
             { prefix: 'isms/policies', text: '方針' },
             { prefix: 'isms/procedures', text: '手順書' },
             { prefix: 'isms/records', text: '記録' },
+            { prefix: 'isms/plans', text: '計画書' },
+            { prefix: 'isms/registers', text: '台帳' },
+            { prefix: 'isms/soa', text: '適用宣言書' },
+            { prefix: 'isms/manual', text: 'マニュアル' },
           ],
         },
-        maxCharactersPerLine: 24,
+        maxCharactersPerLine: 12,
       })(siteConfig)
     }
   })

--- a/docs/public/og-template.svg
+++ b/docs/public/og-template.svg
@@ -2,33 +2,65 @@
   <!-- Background - Clean white -->
   <rect width="1200" height="630" fill="#ffffff"/>
 
+  <!-- Footer bar (center only, taller) -->
+  <rect x="285" y="505" width="630" height="125" fill="#f8fafb"/>
+  <line x1="285" y1="505" x2="915" y2="505" stroke="#e8eef3" stroke-width="1"/>
+
+  <!-- Side panels (outside square safe zone, full height) -->
+  <rect x="0" y="0" width="285" height="630" fill="#f0fdf4"/>
+  <rect x="915" y="0" width="285" height="630" fill="#f0fdf4"/>
+
   <!-- Top accent bar with brand color -->
   <rect width="1200" height="8" fill="#3eaf7c"/>
 
-  <!-- Left accent line -->
-  <rect x="60" y="60" width="6" height="510" fill="#3eaf7c" rx="3"/>
+  <!-- Bottom accent bar with brand color -->
+  <rect y="622" width="1200" height="8" fill="#3eaf7c"/>
 
-  <!-- Site name badge -->
-  <rect x="90" y="80" width="180" height="44" rx="8" fill="#3eaf7c" fill-opacity="0.1"/>
-  <text x="180" y="110" font-family="sans-serif" font-size="22" font-weight="600" fill="#3eaf7c" text-anchor="middle">{{siteName}}</text>
+  <!-- Left vertical accent bar (inner edge of safe zone) -->
+  <rect x="285" y="0" width="8" height="630" fill="#3eaf7c"/>
 
-  <!-- Category badge (if exists) -->
-  <text x="290" y="110" font-family="sans-serif" font-size="20" fill="#666666">{{category}}</text>
+  <!-- Right vertical accent bar (inner edge of safe zone) -->
+  <rect x="907" y="0" width="8" height="630" fill="#3eaf7c"/>
 
-  <!-- Title - 3 lines max -->
-  <text x="90" y="220" font-family="sans-serif" font-size="52" font-weight="700" fill="#1a1a1a">{{line1}}</text>
-  <text x="90" y="290" font-family="sans-serif" font-size="52" font-weight="700" fill="#1a1a1a">{{line2}}</text>
-  <text x="90" y="360" font-family="sans-serif" font-size="52" font-weight="700" fill="#1a1a1a">{{line3}}</text>
+  <!-- Site name - Large -->
+  <text x="600" y="160" font-family="sans-serif" font-size="56" font-weight="700" fill="#3eaf7c" text-anchor="middle">ISMS Guide</text>
 
-  <!-- Footer bar -->
-  <rect x="0" y="540" width="1200" height="90" fill="#f8fafb"/>
-  <line x1="0" y1="540" x2="1200" y2="540" stroke="#e8eef3" stroke-width="1"/>
+  <!-- Subtitle -->
+  <text x="600" y="210" font-family="sans-serif" font-size="24" fill="#333333" text-anchor="middle">ISO/IEC 27001:2022 対応 ISMS 構築ガイド</text>
 
-  <!-- Footer text -->
-  <text x="90" y="595" font-family="sans-serif" font-size="22" fill="#6b7280">ISO/IEC 27001:2022 対応 ISMS 構築ガイド</text>
-  <text x="1110" y="595" font-family="sans-serif" font-size="22" fill="#9ca3af" text-anchor="end">isms-guide.com</text>
+  <!-- Category badge -->
+  <rect x="480" y="245" width="240" height="50" rx="25" fill="#3eaf7c" fill-opacity="0.1"/>
+  <text x="600" y="280" font-family="sans-serif" font-size="28" font-weight="600" fill="#3eaf7c" text-anchor="middle">{{category}}</text>
 
-  <!-- Decorative elements -->
-  <circle cx="1080" cy="140" r="100" fill="#3eaf7c" fill-opacity="0.04"/>
-  <circle cx="1130" cy="200" r="140" fill="#3eaf7c" fill-opacity="0.02"/>
+  <!-- Page title (multi-line) -->
+  <text x="600" y="370" font-family="sans-serif" font-size="48" font-weight="700" fill="#1a1a1a" text-anchor="middle">{{line1}}</text>
+  <text x="600" y="430" font-family="sans-serif" font-size="48" font-weight="700" fill="#1a1a1a" text-anchor="middle">{{line2}}</text>
+  <text x="600" y="485" font-family="sans-serif" font-size="48" font-weight="700" fill="#1a1a1a" text-anchor="middle">{{line3}}</text>
+
+  <!-- Footer line 1: URL -->
+  <text x="600" y="528" font-family="sans-serif" font-size="20" fill="#333333" text-anchor="middle">https://isms-guide.com</text>
+
+  <!-- Footer line 2: CC BY-NC 4.0 icons (official paths, 30px) -->
+  <g transform="translate(600, 560)">
+    <!-- CC logo (official, 30px) -->
+    <g transform="translate(-108, -15)">
+      <path d="M14.972 0c4.196 0 7.769 1.465 10.715 4.393A14.426 14.426 0 0128.9 9.228C29.633 11.04 30 12.964 30 15c0 2.054-.363 3.978-1.085 5.772a13.77 13.77 0 01-3.2 4.754 15.417 15.417 0 01-4.983 3.322A14.932 14.932 0 0114.973 30c-1.982 0-3.88-.38-5.692-1.14a15.087 15.087 0 01-4.875-3.293c-1.437-1.437-2.531-3.058-3.281-4.862A14.71 14.71 0 010 15c0-1.982.38-3.888 1.138-5.719a15.062 15.062 0 013.308-4.915C7.303 1.456 10.812 0 14.972 0zm.055 2.706c-3.429 0-6.313 1.196-8.652 3.589a12.896 12.896 0 00-2.72 4.031 11.814 11.814 0 00-.95 4.675c0 1.607.316 3.156.95 4.646a12.428 12.428 0 002.72 3.992 12.362 12.362 0 003.99 2.679c1.483.616 3.037.924 4.662.924 1.607 0 3.164-.312 4.675-.937a12.954 12.954 0 004.084-2.705c2.339-2.286 3.508-5.152 3.508-8.6 0-1.66-.304-3.231-.91-4.713a11.994 11.994 0 00-2.651-3.965c-2.412-2.41-5.314-3.616-8.706-3.616zm-.188 9.803l-2.01 1.045c-.215-.445-.477-.758-.79-.937-.312-.178-.602-.268-.87-.268-1.34 0-2.01.884-2.01 2.652 0 .803.17 1.446.509 1.928.34.482.84.724 1.5.724.876 0 1.492-.43 1.85-1.286l1.847.937a4.407 4.407 0 01-1.634 1.728c-.696.42-1.464.63-2.303.63-1.34 0-2.42-.41-3.242-1.233-.821-.82-1.232-1.964-1.232-3.428 0-1.428.416-2.562 1.246-3.401.83-.84 1.879-1.26 3.147-1.26 1.858 0 3.188.723 3.992 2.17zm8.652 0l-1.983 1.045c-.214-.445-.478-.758-.79-.937-.313-.178-.613-.268-.897-.268-1.34 0-2.01.884-2.01 2.652 0 .803.17 1.446.51 1.928.338.482.838.724 1.5.724.874 0 1.49-.43 1.847-1.286l1.875.937a4.606 4.606 0 01-1.66 1.728c-.696.42-1.455.63-2.277.63-1.357 0-2.441-.41-3.253-1.233-.814-.82-1.22-1.964-1.22-3.428 0-1.428.415-2.562 1.246-3.401.83-.84 1.879-1.26 3.147-1.26 1.857 0 3.18.723 3.965 2.17z" fill="#333333"/>
+    </g>
+
+    <!-- BY icon (official, 30px) -->
+    <g transform="translate(-74, -15)">
+      <path d="M14.973 0c4.213 0 7.768 1.446 10.66 4.34C28.544 7.25 30 10.803 30 15c0 4.215-1.43 7.723-4.287 10.526C22.678 28.51 19.098 30 14.973 30c-4.054 0-7.571-1.474-10.553-4.42C1.474 22.633 0 19.107 0 15S1.474 7.34 4.42 4.34C7.313 1.446 10.83 0 14.973 0zm.054 2.706c-3.41 0-6.295 1.196-8.652 3.589-2.447 2.5-3.67 5.402-3.67 8.706 0 3.321 1.214 6.196 3.642 8.624 2.429 2.429 5.322 3.642 8.679 3.642 3.339 0 6.25-1.222 8.732-3.67 2.358-2.267 3.536-5.133 3.536-8.598 0-3.41-1.197-6.311-3.589-8.705-2.392-2.392-5.285-3.588-8.678-3.588zm4.018 8.57v6.134H17.33v7.286h-4.66V17.41h-1.714v-6.134a.93.93 0 01.28-.683.933.933 0 01.684-.281h6.161c.25 0 .474.093.67.28a.912.912 0 01.294.684zM12.91 7.42c0-1.41.696-2.116 2.09-2.116s2.09.705 2.09 2.116c0 1.393-.697 2.09-2.09 2.09-1.393 0-2.09-.697-2.09-2.09z" fill="#333333"/>
+    </g>
+
+    <!-- NC icon (official, 30px) -->
+    <g transform="translate(-40, -15)">
+      <path d="M14.973 0c4.214 0 7.768 1.446 10.66 4.339C28.544 7.232 30 10.786 30 15c0 4.215-1.429 7.723-4.287 10.527C22.678 28.51 19.097 30 14.973 30c-4.072 0-7.59-1.482-10.553-4.446C1.474 22.607 0 19.09 0 15c0-4.107 1.474-7.66 4.42-10.66C7.313 1.446 10.83 0 14.973 0zM3.375 10.956c-.446 1.232-.67 2.58-.67 4.045 0 3.321 1.214 6.196 3.642 8.624 2.447 2.412 5.34 3.617 8.679 3.617 3.375 0 6.285-1.223 8.733-3.67.875-.839 1.561-1.714 2.061-2.626l-5.651-2.518a3.866 3.866 0 01-1.433 2.317c-.76.598-1.657.943-2.693 1.031v2.304h-1.74v-2.304c-1.661-.017-3.18-.615-4.554-1.794l2.063-2.089c.981.91 2.098 1.366 3.348 1.366.517 0 .96-.116 1.326-.349.366-.231.55-.615.55-1.151 0-.376-.135-.68-.402-.911l-1.447-.617-1.767-.804-2.384-1.044-7.661-3.427zm11.652-8.278c-3.41 0-6.295 1.206-8.652 3.616-.59.59-1.143 1.26-1.66 2.01l5.732 2.571a3.513 3.513 0 011.42-1.888c.695-.473 1.508-.737 2.437-.79V5.893h1.741v2.304c1.376.071 2.625.535 3.75 1.392L17.84 11.6c-.84-.59-1.697-.884-2.572-.884-.464 0-.88.09-1.245.267-.366.179-.55.483-.55.911 0 .125.045.25.134.375l1.902.858 1.313.59 2.41 1.07 7.687 3.429c.25-1.054.375-2.125.375-3.214 0-3.447-1.196-6.349-3.588-8.707-2.375-2.41-5.27-3.616-8.68-3.616z" fill="#333333"/>
+    </g>
+
+    <!-- Text label -->
+    <text x="0" y="5" font-family="sans-serif" font-size="18" font-weight="600" fill="#333333">CC BY-NC 4.0</text>
+  </g>
+
+  <!-- Footer line 3: Copyright -->
+  <text x="600" y="602" font-family="sans-serif" font-size="20" fill="#333333" text-anchor="middle"><tspan font-size="26" dy="2">©</tspan><tspan dy="-2"> 2026 Business Technology Association Japan</tspan></text>
 </svg>


### PR DESCRIPTION
## 概要
- OGPテンプレートを新デザインに刷新
- 正方形クロップ（SNS表示）に対応したセーフゾーン設計
- CC BY-NC 4.0 公式アイコンをSVGパスとして埋め込み
- OGP生成設定の最適化

## 変更ファイル
- `docs/public/og-template.svg` - 新デザインテンプレート
- `docs/.vitepress/config.mts` - OGP生成設定

## 変更内容

### テンプレート (og-template.svg)
- 中央配置レイアウト（正方形セーフゾーン: 285px - 915px）
- サイドパネル（セーフゾーン外）を薄緑で塗りつぶし
- 緑のアクセントバー（上下左右）
- フッター3行構成: URL → CC BY-NC 4.0アイコン → Copyright
- 公式CCアイコンパス（30x30）を直接埋め込み

### 設定 (config.mts)
- `maxCharactersPerLine`: 24 → 12（正方形セーフゾーン対応）
- カテゴリ追加: 計画書、台帳、適用宣言書、マニュアル

## テスト
- [x] SVGテンプレートのプレビュー確認
- [x] フッターの行間・アイコンサイズ確認

Closes #73