### PR TITLE
fix: ヘッダーロゴの配置とサイズをレスポンシブ対応

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -39,14 +39,44 @@
 }
 
 /* Header alignment: match content area padding */
+/* PC */
 @media (min-width: 960px) {
+  .VPNavBar .wrapper {
+    padding: 0 !important;
+  }
+
   .VPNavBar .container {
+    max-width: 1280px !important;
+    margin: 0 auto !important;
     padding: 0 64px !important;
   }
 
   .VPNavBarTitle .VPImage.logo {
     height: 37px !important;
     width: auto !important;
+    margin-top: 8px !important;
+  }
+}
+
+/* Tablet */
+@media (min-width: 640px) and (max-width: 959px) {
+  .VPNavBar .wrapper {
+    padding: 0 48px !important;
+  }
+
+  .VPNavBarTitle .VPImage.logo {
+    height: 32px !important;
+    width: auto !important;
+    margin-top: 8px !important;
+  }
+}
+
+/* Mobile */
+@media (max-width: 639px) {
+  .VPNavBarTitle .VPImage.logo {
+    height: 28px !important;
+    width: auto !important;
+    margin-top: 8px !important;
   }
 }
 


### PR DESCRIPTION
## 概要
- PC（960px以上）: max-width 1280px、padding 64px、ロゴ37px
- タブレット（640-959px）: padding 48px、ロゴ32px
- モバイル（639px以下）: ロゴ28px
- 全サイズでmargin-top 8pxを追加してロゴの視覚的な中央揃えを改善

## 変更ファイル
- `docs/.vitepress/theme/custom.css`

## テスト
- [x] PC表示確認済み
- [x] タブレット表示確認済み
- [x] モバイル表示確認済み