### PR TITLE
fix: Azure AD を Microsoft Entra ID に名称変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,12 @@ npm run build
 
 | サービス | 認証方法 | 特徴 |
 |----------|----------|------|
-| **Cloudflare Pages + Zero Trust Access** | IdP連携（Google, Okta, Azure AD等） | 無料枠あり、グローバルCDN |
+| **Cloudflare Pages + Zero Trust Access** | IdP連携（Google, Okta, Microsoft Entra ID等） | 無料枠あり、グローバルCDN |
 | **AWS Amplify + Cognito** | Cognito User Pool, SAML, OIDC | AWS エコシステムとの統合 |
 | **Vercel + Auth0** | Auth0 によるIdP連携 | シンプルな設定 |
-| **Azure Static Web Apps + Azure AD** | Azure AD | Microsoft 365 環境との親和性 |
+| **Azure Static Web Apps + Microsoft Entra ID** | Microsoft Entra ID | Microsoft 365 環境との親和性 |
+
+※ Microsoft Entra ID は Azure Active Directory（Azure AD）の後継サービスです。
 
 いずれの方法でも、ビルド成果物（`docs/.vitepress/dist`）を静的ホスティングし、その前段で認証を設定します。
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,10 +74,12 @@ ISMS Guide は、ISO/IEC 27001:2022 に基づく情報セキュリティマネ�
 
 | サービス | 認証方法 | 特徴 |
 |----------|----------|------|
-| **Cloudflare Pages + Zero Trust Access** | IdP連携（Google, Okta, Azure AD等） | 無料枠あり、グローバルCDN |
+| **Cloudflare Pages + Zero Trust Access** | IdP連携（Google, Okta, Microsoft Entra ID等） | 無料枠あり、グローバルCDN |
 | **AWS Amplify + Cognito** | Cognito User Pool, SAML, OIDC | AWS エコシステムとの統合 |
 | **Vercel + Auth0** | Auth0 によるIdP連携 | シンプルな設定 |
-| **Azure Static Web Apps + Azure AD** | Azure AD | Microsoft 365 環境との親和性 |
+| **Azure Static Web Apps + Microsoft Entra ID** | Microsoft Entra ID | Microsoft 365 環境との親和性 |
+
+※ Microsoft Entra ID は Azure Active Directory（Azure AD）の後継サービスです。
 
 静的サイトとして出力されるため、上記以外のホスティングサービスでも認証機能を組み合わせて利用可能です。
 


### PR DESCRIPTION
## 概要
- 「Azure AD」の表記を「Microsoft Entra ID」に更新
- テーブル下に旧称の注釈を追加

## 変更ファイル
- `docs/index.md` - TOP画面の社内デプロイ比較表
- `README.md` - 同内容の比較表

## 関連ISSUE
Closes #92

## テスト
- [x] 全箇所の Azure AD が Microsoft Entra ID に更新されていることを確認
- [x] 注釈が追加されていることを確認