### PR TITLE
chore: 問い合わせ先を情シスSlackに変更

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: "ディスカッション"
-    url: https://github.com/btajp/isms-guide/discussions
-    about: "質問や議論は Discussions をご利用ください"
+    url: https://corp-engr.jp
+    about: "質問や議論は情シスSlackの #topic-isms-guide チャンネルをご利用ください"

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ npm test
 
 Issue や Pull Request を歓迎します。
 
+- バグや機能要望、コンテンツの誤りは[ISSUE](https://github.com/btajp/isms-guide/issues)へ
+- 質問や議論は[情シスSlack](https://corp-engr.jp)の #topic-isms-guide チャンネルをご利用ください
+
 ## メンテナー
 
 [一般社団法人日本ビジネステクノロジー協会（BTAJP）](https://btajp.org)


### PR DESCRIPTION
## 概要
- ISSUEテンプレートのディスカッションリンクをGitHub Discussionsから情シスSlack (#topic-isms-guide) に変更
- READMEにISSUE報告先とSlackチャンネルの案内を追加

## 変更ファイル
- `.github/ISSUE_TEMPLATE/config.yml`
- `README.md`

## テスト
- [x] 変更内容を確認済み