### PR TITLE
style: center blog content to footer width

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -197,6 +197,15 @@ html body .VPSidebar > div {
   }
 }
 
+@media (min-width: 960px) {
+  .VPContent.has-sidebar .VPPage > div {
+    max-width: 688px;
+    margin: 0 auto;
+    width: 100%;
+    transform: translateX(calc(var(--vp-sidebar-width) * -0.5));
+  }
+}
+
 /* Keep divider aligned with the aside and reach the header */
 @media (min-width: 960px) {
   .VPDoc.has-aside .aside::before {


### PR DESCRIPTION
Blog pages use the page layout with a left sidebar, so content was visually wider than the footer. Constrain the blog content to 688px and shift it left by half the sidebar width so it aligns with the centered footer.